### PR TITLE
Update CMakeLists.txt for Windows compile

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,4 +11,4 @@ set(PROJECT_F ${CMAKE_CURRENT_SOURCE_DIR}/source)
 project (spatch)
 
 add_executable (spatch ${PROJECT_F}/main.cpp)
-target_link_libraries (spatch ssh)
+target_link_libraries (spatch ssh argp)


### PR DESCRIPTION
Add argp lib in CMakeLists.txt.
Required on Windows to compile for #12.